### PR TITLE
fix building recovery under cm-11.0

### DIFF
--- a/selinux/device.te
+++ b/selinux/device.te
@@ -1,3 +1,2 @@
 type efs_block_device, dev_type;
-type powervr_device, dev_type, mlstrustedobject;
 type rfkill_device, dev_type;


### PR DESCRIPTION
this is no longer needed as it breaks building under cm-11.0 which defines it in external/sepolicy
