### PR TITLE
P51XX: adding performance profiles

### DIFF
--- a/overlay/cm/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/cm/frameworks/base/core/res/res/values/config.xml
@@ -23,5 +23,9 @@
 
     <!-- Boolean to enable stk functionality on Samsung phones -->
     <bool name="config_samsung_stk">true</bool>
+    
+    <!-- Performance profiles -->
+    <string name="config_perf_profile_prop">sys.perf.profile</string>
+    <string name="config_perf_profile_default_entry">1</string>
 
 </resources>

--- a/rootdir/init.espresso10.rc
+++ b/rootdir/init.espresso10.rc
@@ -450,3 +450,14 @@ on property:ro.bootmode=charger
 service charger /charger
     class charger
     user root
+
+## CyanogenMod Performance Profiles
+# Powersave
+on property:sys.perf.profile=0
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor powersave
+# Balanced, here interactive governor
+on property:sys.perf.profile=1
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor interactive
+# Performance
+on property:sys.perf.profile=2
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor performance


### PR DESCRIPTION
This should make the performance tile (or widget) working. So far it is untested, as my CM12.1 copy does not want to build an image, but I beleave it should as the Samsung S3 (i9300) team also made it work like that.
The only difference is that I choosed for balanced performance the interactive governor as it is currently the default.
