### PR TITLE
P51XX: Splitting "wpa" and "p2p" into seperate *_supplicant.conf files

### DIFF
--- a/configs/p2p_supplicant_overlay.conf
+++ b/configs/p2p_supplicant_overlay.conf
@@ -1,0 +1,12 @@
+disable_scan_offload=1
+p2p_listen_reg_class=81
+p2p_listen_channel=1
+p2p_oper_reg_class=81
+p2p_oper_channel=1
+manufacturer=SAMSUNG_ELECTRONICS
+model_name=SAMSUNG_MOBILE
+model_number=2013
+serial_number=19691101
+update_config=1
+no_ctrl_interface=
+

--- a/configs/p2p_supplicant_overlay.conf
+++ b/configs/p2p_supplicant_overlay.conf
@@ -9,4 +9,3 @@ model_number=2013
 serial_number=19691101
 update_config=1
 no_ctrl_interface=
-

--- a/configs/wpa_supplicant.conf
+++ b/configs/wpa_supplicant.conf
@@ -1,9 +1,0 @@
-update_config=1
-ctrl_interface=wlan0
-eapol_version=1
-ap_scan=1
-fast_reauth=1
-p2p_listen_reg_class=81
-p2p_listen_channel=1
-p2p_oper_reg_class=115
-p2p_oper_channel=48

--- a/configs/wpa_supplicant_overlay.conf
+++ b/configs/wpa_supplicant_overlay.conf
@@ -1,0 +1,4 @@
+p2p_disabled=1
+autoscan=samsung_exponential:8:128
+update_config=1
+no_ctrl_interface=

--- a/p51xx-common.mk
+++ b/p51xx-common.mk
@@ -50,6 +50,10 @@ PRODUCT_PACKAGES += \
     wpa_supplicant \
     wpa_supplicant.conf
 
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/configs/wpa_supplicant_overlay.conf:system/etc/wifi/wpa_supplicant_overlay.conf \
+    $(LOCAL_PATH)/configs/p2p_supplicant_overlay.conf:system/etc/wifi/p2p_supplicant_overlay.conf
+
 PRODUCT_PROPERTY_OVERRIDES += \
     wifi.interface=wlan0 \
     wifi.supplicant_scan_interval=15
@@ -129,5 +133,4 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_TAGS += dalvik.gc.type-precise
 
 $(call inherit-product, frameworks/native/build/tablet-dalvik-heap.mk)
-$(call inherit-product-if-exists, hardware/broadcom/wlan/bcmdhd/firmware/bcm4330/device-bcm.mk)
 $(call inherit-product, vendor/samsung/p51xx/p51xx-vendor.mk)

--- a/rootdir/init.espresso10.rc
+++ b/rootdir/init.espresso10.rc
@@ -78,8 +78,6 @@ on post-fs-data
     # we will remap this as /storage/sdcard0 with the sdcard fuse tool
     mkdir /data/media 0770 media_rw media_rw
     chown media_rw media_rw /data/media
-    mkdir /data/misc/wifi 0770 wifi system
-    mkdir /data/misc/wifi/sockets 0770 wifi wifi
 
 # dmrpc
     mkdir /data/smc 0770 drmrpc drmrpc
@@ -339,12 +337,12 @@ service fuse_usbdisk0 /system/bin/sdcard -u 1023 -g 1023 -d /mnt/media_rw/usbdis
     disabled
 
 service p2p_supplicant /system/bin/wpa_supplicant \
-    -iwlan0 -Dnl80211 -iwlan0 -c/data/misc/wifi/wpa_supplicant.conf \
+    -iwlan0 -Dnl80211 -c/data/misc/wifi/wpa_supplicant.conf \
     -I/system/etc/wifi/wpa_supplicant_overlay.conf -N \
     -ip2p0 -Dnl80211 -c /data/misc/wifi/p2p_supplicant.conf \
     -I/system/etc/wifi/p2p_supplicant_overlay.conf \
-    -puse_p2p_group_interface=1 -e/data/misc/wifi/entropy.bin \
-    -g@android:wpa_wlan0
+    -puse_p2p_group_interface=1 \
+    -e/data/misc/wifi/entropy.bin -g@android:wpa_wlan0
     #   we will start as root and wpa_supplicant will switch to user wifi
     #   after setting up the capabilities required for WEXT
     #   user wifi


### PR DESCRIPTION
However, does not make wifi direct working. Seems to be a driver related problem now.

The work in this pull request is based on the latest work here on Cyanogenmod and on this commit for smdk4412-common (Samsung i9300):
https://github.com/ArchiDroid/android_device_samsung_smdk4412-common/commit/4a1e33afb5038bd8c8fb59a728bde9d49f284234
